### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/181/571/421181571.geojson
+++ b/data/421/181/571/421181571.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"VI",
     "wof:created":1459009300,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4948755bb3dc7b176bb611d686c6dfa5",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":421181571,
-    "wof:lastmodified":1566647190,
+    "wof:lastmodified":1582381960,
     "wof:name":"Great Pond",
     "wof:parent_id":85680579,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.