### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/537/083/102537083.geojson
+++ b/data/102/537/083/102537083.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0647\u0646\u0631\u0649 \u0627\u0649 \u0631\u0648\u0647\u0644\u0633\u0646"
+    ],
     "name:ast_x_preferred":[
         "Aeropuertu Internacional Henry E. Rohlsen"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:fra_x_preferred":[
         "a\u00e9roport international Henry E. Rohlsen"
+    ],
+    "name:ind_x_preferred":[
+        "Bandara Henry E. Rohlsen"
     ],
     "name:ita_x_preferred":[
         "Aeroporto Henry E. Rohlsen"
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":102537083,
-    "wof:lastmodified":1566647167,
+    "wof:lastmodified":1690921370,
     "wof:name":"Henry E Rohlson International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/537/085/102537085.geojson
+++ b/data/102/537/085/102537085.geojson
@@ -16,6 +16,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0633\u064a\u0631\u064a\u0644 \u0627\u0649 \u0643\u064a\u0646\u062c"
+    ],
     "name:ceb_x_preferred":[
         "Cyril E. King Airport"
     ],
@@ -34,6 +37,9 @@
     "name:eng_x_variant":[
         "STT",
         "TIST"
+    ],
+    "name:epo_x_preferred":[
+        "Internacia Flughaveno Cyril E. King"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0633\u06cc\u0631\u0644 \u06af\u0631\u06cc \u06a9\u06cc\u0646\u06af"
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":102537085,
-    "wof:lastmodified":1566647167,
+    "wof:lastmodified":1690921370,
     "wof:name":"Cyril E King International Airport",
     "wof:parent_id":101734689,
     "wof:placetype":"campus",

--- a/data/112/580/010/3/1125800103.geojson
+++ b/data/112/580/010/3/1125800103.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0634\u0627\u0631\u0644\u0648\u062a \u0623\u0645\u0627\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0627\u0631\u0644\u0648\u062a \u0627\u0645\u0627\u0644\u0649"
+    ],
     "name:ast_x_preferred":[
         "Charlotte Amalie"
     ],
@@ -97,6 +100,15 @@
     "name:fra_x_preferred":[
         "Charlotte Amalie"
     ],
+    "name:frr_x_preferred":[
+        "Charlotte Amalie"
+    ],
+    "name:fry_x_preferred":[
+        "Charlotte Amalie"
+    ],
+    "name:gle_x_preferred":[
+        "Charlotte Amalie"
+    ],
     "name:glg_x_preferred":[
         "Charlotte Amalie"
     ],
@@ -147,6 +159,9 @@
     ],
     "name:lav_x_preferred":[
         "\u0160arlote Am\u0101lija"
+    ],
+    "name:lij_x_preferred":[
+        "Charlotte Amalie"
     ],
     "name:lit_x_preferred":[
         "\u0160arlot\u0117 Amalija"
@@ -208,6 +223,9 @@
     "name:sqi_x_preferred":[
         "Sharlot Amalie"
     ],
+    "name:srd_x_preferred":[
+        "Charlotte Amalie"
+    ],
     "name:srp_x_preferred":[
         "\u0428\u0430\u0440\u043b\u043e\u0442\u0430 \u0410\u043c\u0430\u043b\u0438\u0458\u0430"
     ],
@@ -249,6 +267,9 @@
     ],
     "name:war_x_preferred":[
         "Charlotte Amalie"
+    ],
+    "name:wuu_x_preferred":[
+        "\u590f\u6d1b\u7279\u963f\u9a6c\u5229\u4e9a"
     ],
     "name:yor_x_preferred":[
         "Charlotte Amalie"
@@ -312,7 +333,7 @@
         }
     ],
     "wof:id":1125800103,
-    "wof:lastmodified":1566647191,
+    "wof:lastmodified":1690921381,
     "wof:name":"Charlotte Amalie",
     "wof:parent_id":85680571,
     "wof:placetype":"locality",

--- a/data/112/580/494/7/1125804947.geojson
+++ b/data/112/580/494/7/1125804947.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0641\u0631\u064a\u062f\u0631\u064a\u0643\u0633\u062a\u064a\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0631\u064a\u062f\u0631\u064a\u0643\u0633\u062a\u064a\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Frederiksted"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u0631\u062f\u0631\u06cc\u06a9\u0633\u062a\u062f"
     ],
@@ -53,6 +59,9 @@
         "Frederiksted"
     ],
     "name:fra_x_preferred":[
+        "Frederiksted"
+    ],
+    "name:frr_x_preferred":[
         "Frederiksted"
     ],
     "name:guj_x_preferred":[
@@ -198,7 +207,7 @@
         }
     ],
     "wof:id":1125804947,
-    "wof:lastmodified":1566647192,
+    "wof:lastmodified":1690921381,
     "wof:name":"Frederiksted",
     "wof:parent_id":85680579,
     "wof:placetype":"locality",

--- a/data/112/589/554/7/1125895547.geojson
+++ b/data/112/589/554/7/1125895547.geojson
@@ -34,6 +34,12 @@
     "name:nob_x_preferred":[
         "Coral Bay"
     ],
+    "name:pol_x_preferred":[
+        "Coral Bay"
+    ],
+    "name:por_x_preferred":[
+        "Coral Bay"
+    ],
     "name:und_x_variant":[
         "Coralbay"
     ],
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":1125895547,
-    "wof:lastmodified":1566647191,
+    "wof:lastmodified":1690921380,
     "wof:name":"Coral Bay",
     "wof:parent_id":85680575,
     "wof:placetype":"locality",

--- a/data/112/589/556/7/1125895567.geojson
+++ b/data/112/589/556/7/1125895567.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0631\u064a\u0633\u062a\u064a\u0627\u0646\u0633\u062a\u064a\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0631\u064a\u0633\u062a\u064a\u0627\u0646\u0633\u062a\u064a\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0631\u06cc\u0633\u062a\u06cc\u0627\u0646\u0633\u062a\u062f"
     ],
@@ -56,6 +59,9 @@
         "Christiansted"
     ],
     "name:fra_x_preferred":[
+        "Christiansted"
+    ],
+    "name:frr_x_preferred":[
         "Christiansted"
     ],
     "name:glg_x_preferred":[
@@ -103,6 +109,12 @@
     "name:mar_x_preferred":[
         "\u0916\u094d\u0930\u093f\u0936\u094d\u091a\u0928\u0938\u094d\u091f\u0947\u0921"
     ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0440\u0438\u0441\u0442\u0438\u0430\u043d\u0441\u0442\u044d\u0434"
+    ],
+    "name:mlt_x_preferred":[
+        "Christiansted"
+    ],
     "name:msa_x_preferred":[
         "Christiansted"
     ],
@@ -120,6 +132,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u0440\u0438\u0441\u0442\u0438\u0430\u043d\u0441\u0442\u0435\u0434"
+    ],
+    "name:sco_x_preferred":[
+        "Christiansted"
     ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dca\u0dbb\u0dd2\u0dc3\u0dca\u0da7\u0dd2\u0dba\u0db1\u0dca\u0dc3\u0dca\u0da7\u0da9\u0dca"
@@ -216,7 +231,7 @@
         }
     ],
     "wof:id":1125895567,
-    "wof:lastmodified":1566647191,
+    "wof:lastmodified":1690921380,
     "wof:name":"Christiansted",
     "wof:parent_id":85680579,
     "wof:placetype":"locality",

--- a/data/112/596/965/3/1125969653.geojson
+++ b/data/112/596/965/3/1125969653.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0634\u0627\u0631\u0644\u0648\u062a \u0623\u0645\u0627\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0627\u0631\u0644\u0648\u062a \u0627\u0645\u0627\u0644\u0649"
+    ],
     "name:ast_x_preferred":[
         "Charlotte Amalie"
     ],
@@ -100,6 +103,15 @@
     "name:fra_x_preferred":[
         "Charlotte Amalie"
     ],
+    "name:frr_x_preferred":[
+        "Charlotte Amalie"
+    ],
+    "name:fry_x_preferred":[
+        "Charlotte Amalie"
+    ],
+    "name:gle_x_preferred":[
+        "Charlotte Amalie"
+    ],
     "name:glg_x_preferred":[
         "Charlotte Amalie"
     ],
@@ -153,6 +165,9 @@
     ],
     "name:lav_x_preferred":[
         "\u0160arlote Am\u0101lija"
+    ],
+    "name:lij_x_preferred":[
+        "Charlotte Amalie"
     ],
     "name:lit_x_preferred":[
         "\u0160arlot\u0117 Amalija"
@@ -223,6 +238,9 @@
     "name:sqi_x_preferred":[
         "Sharlot Amalie"
     ],
+    "name:srd_x_preferred":[
+        "Charlotte Amalie"
+    ],
     "name:srp_x_preferred":[
         "\u0428\u0430\u0440\u043b\u043e\u0442\u0430 \u0410\u043c\u0430\u043b\u0438\u0458\u0430"
     ],
@@ -267,6 +285,9 @@
     ],
     "name:war_x_preferred":[
         "Charlotte Amalie"
+    ],
+    "name:wuu_x_preferred":[
+        "\u590f\u6d1b\u7279\u963f\u9a6c\u5229\u4e9a"
     ],
     "name:yor_x_preferred":[
         "Charlotte Amalie"
@@ -317,7 +338,7 @@
         }
     ],
     "wof:id":1125969653,
-    "wof:lastmodified":1566647192,
+    "wof:lastmodified":1690921382,
     "wof:name":"Charlotte Amalie",
     "wof:parent_id":85680571,
     "wof:placetype":"locality",

--- a/data/114/190/837/3/1141908373.geojson
+++ b/data/114/190/837/3/1141908373.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-64.7499860043,17.7503751821,-64.7499860043,17.7503751821",
+    "geom:bbox":"-64.749986,17.750375,-64.749986,17.750375",
     "geom:latitude":17.750375,
     "geom:longitude":-64.749986,
     "iso:country":"VI",
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
+        "\u0643\u0631\u064a\u0633\u062a\u064a\u0627\u0646\u0633\u062a\u064a\u062f"
+    ],
+    "name:arz_x_preferred":[
         "\u0643\u0631\u064a\u0633\u062a\u064a\u0627\u0646\u0633\u062a\u064a\u062f"
     ],
     "name:azb_x_preferred":[
@@ -52,6 +55,9 @@
         "Christiansted"
     ],
     "name:fra_x_preferred":[
+        "Christiansted"
+    ],
+    "name:frr_x_preferred":[
         "Christiansted"
     ],
     "name:glg_x_preferred":[
@@ -99,6 +105,12 @@
     "name:mar_x_preferred":[
         "\u0916\u094d\u0930\u093f\u0936\u094d\u091a\u0928\u0938\u094d\u091f\u0947\u0921"
     ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0440\u0438\u0441\u0442\u0438\u0430\u043d\u0441\u0442\u044d\u0434"
+    ],
+    "name:mlt_x_preferred":[
+        "Christiansted"
+    ],
     "name:msa_x_preferred":[
         "Christiansted"
     ],
@@ -116,6 +128,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u0440\u0438\u0441\u0442\u0438\u0430\u043d\u0441\u0442\u0435\u0434"
+    ],
+    "name:sco_x_preferred":[
+        "Christiansted"
     ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dca\u0dbb\u0dd2\u0dc3\u0dca\u0da7\u0dd2\u0dba\u0db1\u0dca\u0dc3\u0dca\u0da7\u0da9\u0dca"
@@ -264,7 +279,7 @@
     },
     "wof:country":"VI",
     "wof:created":1499130889,
-    "wof:geomhash":"407f44aaf34cc4bfbc8a2c3d4dc03d82",
+    "wof:geomhash":"9a2f1e0fc3b994cd18153b4de3fa61aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -276,7 +291,7 @@
         }
     ],
     "wof:id":1141908373,
-    "wof:lastmodified":1566647198,
+    "wof:lastmodified":1690921382,
     "wof:name":"Christiansted",
     "wof:parent_id":85680579,
     "wof:placetype":"locality",
@@ -286,10 +301,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -64.74998600427779,
-    17.75037518205357,
-    -64.74998600427779,
-    17.75037518205357
+    -64.749986,
+    17.750375,
+    -64.749986,
+    17.750375
 ],
-  "geometry": {"coordinates":[-64.74998600427779,17.75037518205357],"type":"Point"}
+  "geometry": {"coordinates":[-64.74998600000001,17.750375],"type":"Point"}
 }

--- a/data/421/181/067/421181067.geojson
+++ b/data/421/181/067/421181067.geojson
@@ -29,6 +29,9 @@
     "name:bar_x_preferred":[
         "Altona"
     ],
+    "name:bel_x_preferred":[
+        "\u0410\u043b\u044c\u0442\u043e\u043d\u0430"
+    ],
     "name:bre_x_preferred":[
         "Altona"
     ],
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":421181067,
-    "wof:lastmodified":1566647190,
+    "wof:lastmodified":1690921376,
     "wof:name":"Altona",
     "wof:parent_id":85680571,
     "wof:placetype":"locality",

--- a/data/421/181/571/421181571.geojson
+++ b/data/421/181/571/421181571.geojson
@@ -20,6 +20,9 @@
     "name:eng_x_preferred":[
         "Great Pond"
     ],
+    "name:hrv_x_preferred":[
+        "Great Pond"
+    ],
     "name:nld_x_preferred":[
         "Great Pond"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":421181571,
-    "wof:lastmodified":1582381960,
+    "wof:lastmodified":1690921377,
     "wof:name":"Great Pond",
     "wof:parent_id":85680579,
     "wof:placetype":"locality",

--- a/data/421/187/307/421187307.geojson
+++ b/data/421/187/307/421187307.geojson
@@ -113,6 +113,9 @@
     "name:ita_x_preferred":[
         "Annaberg"
     ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30f3\u30ca\u30d9\u30eb\u30af"
+    ],
     "name:kon_x_preferred":[
         "Annaberg"
     ],
@@ -277,7 +280,7 @@
         }
     ],
     "wof:id":421187307,
-    "wof:lastmodified":1566647188,
+    "wof:lastmodified":1690921373,
     "wof:name":"Annaberg",
     "wof:parent_id":85680575,
     "wof:placetype":"locality",

--- a/data/421/199/365/421199365.geojson
+++ b/data/421/199/365/421199365.geojson
@@ -140,6 +140,9 @@
     "name:egl_x_preferred":[
         "Hoffman"
     ],
+    "name:ell_x_preferred":[
+        "\u03a7\u03cc\u03c6\u03bc\u03b1\u03bd"
+    ],
     "name:eml_x_preferred":[
         "Hoffman"
     ],
@@ -355,6 +358,9 @@
     ],
     "name:lav_x_preferred":[
         "Hoffman"
+    ],
+    "name:lav_x_variant":[
+        "Hofmans"
     ],
     "name:lfn_x_preferred":[
         "Hoffman"
@@ -739,7 +745,7 @@
         }
     ],
     "wof:id":421199365,
-    "wof:lastmodified":1566647190,
+    "wof:lastmodified":1690921378,
     "wof:name":"Hoffman",
     "wof:parent_id":85680571,
     "wof:placetype":"locality",

--- a/data/421/204/469/421204469.geojson
+++ b/data/421/204/469/421204469.geojson
@@ -230,6 +230,9 @@
     "name:wol_x_preferred":[
         "Hermitage"
     ],
+    "name:zho_x_preferred":[
+        "\u8d6b\u7c73\u7279\u5409"
+    ],
     "name:zul_x_preferred":[
         "Hermitage"
     ],
@@ -280,7 +283,7 @@
         }
     ],
     "wof:id":421204469,
-    "wof:lastmodified":1566647187,
+    "wof:lastmodified":1690921373,
     "wof:name":"Hermitage",
     "wof:parent_id":85680575,
     "wof:placetype":"locality",

--- a/data/856/805/71/85680571.geojson
+++ b/data/856/805/71/85680571.geojson
@@ -82,6 +82,9 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30c8\u30fc\u30de\u30b9"
     ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30a4\u30f3\u30c8\u30fb\u30c8\u30de\u30b9"
+    ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8 \ud1a0\ub9c8\uc2a4"
     ],
@@ -223,7 +226,7 @@
         "wd:id":"Q20851010"
     },
     "wof:country":"VI",
-    "wof:geomhash":"f4c5f2451adc1920123c3bbdf0a5e52f",
+    "wof:geomhash":"1ec997c2912351e5cf00d8cfa2be524e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -240,7 +243,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690921371,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632169,
     "wof:placetype":"region",

--- a/data/856/805/75/85680575.geojson
+++ b/data/856/805/75/85680575.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u062c\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u062c\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "San Xuan"
     ],
@@ -80,6 +83,9 @@
     "name:fra_x_preferred":[
         "Saint John"
     ],
+    "name:frr_x_preferred":[
+        "Saint John"
+    ],
     "name:glg_x_preferred":[
         "San Xo\u00e1n"
     ],
@@ -106,6 +112,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30f3\u5cf6"
+    ],
+    "name:jpn_x_variant":[
+        "\u30bb\u30a4\u30f3\u30c8\u30fb\u30b8\u30e7\u30f3\u5cf6"
     ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0c9c\u0cbe\u0ca8\u0ccd"
@@ -309,7 +318,7 @@
         "wk:page":"Saint John, U.S. Virgin Islands"
     },
     "wof:country":"VI",
-    "wof:geomhash":"1fa661cbd390b0abe00bcc3fa7b3b224",
+    "wof:geomhash":"e30681a127103cbc20b4684d13f74638",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -326,7 +335,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690921370,
     "wof:name":"Saint John",
     "wof:parent_id":85632169,
     "wof:placetype":"region",

--- a/data/856/805/79/85680579.geojson
+++ b/data/856/805/79/85680579.geojson
@@ -71,6 +71,9 @@
     "name:hun_x_preferred":[
         "Saint Croix"
     ],
+    "name:hye_x_preferred":[
+        "\u054d\u0565\u0576\u0569 \u0554\u0580\u0578\u0582\u057d"
+    ],
     "name:ind_x_preferred":[
         "Saint Croix"
     ],
@@ -94,6 +97,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u041a\u0440\u0443\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u0421\u0430\u043d\u0442\u0430-\u041a\u0440\u0443\u0441"
     ],
     "name:spa_x_preferred":[
         "Santa Cruz"
@@ -224,7 +230,7 @@
         "wd:id":"Q20852568"
     },
     "wof:country":"VI",
-    "wof:geomhash":"fc13adee267f974232c8737ea332608b",
+    "wof:geomhash":"5052c38823424f82f71c6adc3340196d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -241,7 +247,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690921371,
     "wof:name":"Saint Croix",
     "wof:parent_id":85632169,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.