### PR TITLE
vi concordances, placetype local, and more

### DIFF
--- a/data/856/805/71/85680571.geojson
+++ b/data/856/805/71/85680571.geojson
@@ -225,8 +225,9 @@
         "uscensus:geoid":"78010",
         "wd:id":"Q20851010"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"VI",
-    "wof:geomhash":"1ec997c2912351e5cf00d8cfa2be524e",
+    "wof:geomhash":"f4c5f2451adc1920123c3bbdf0a5e52f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -243,7 +244,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921371,
+    "wof:lastmodified":1695885335,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632169,
     "wof:placetype":"region",

--- a/data/856/805/75/85680575.geojson
+++ b/data/856/805/75/85680575.geojson
@@ -317,8 +317,9 @@
         "wd:id":"Q849441",
         "wk:page":"Saint John, U.S. Virgin Islands"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"VI",
-    "wof:geomhash":"e30681a127103cbc20b4684d13f74638",
+    "wof:geomhash":"1fa661cbd390b0abe00bcc3fa7b3b224",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +336,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921370,
+    "wof:lastmodified":1695885335,
     "wof:name":"Saint John",
     "wof:parent_id":85632169,
     "wof:placetype":"region",

--- a/data/856/805/79/85680579.geojson
+++ b/data/856/805/79/85680579.geojson
@@ -229,8 +229,9 @@
         "uscensus:geoid":"78030",
         "wd:id":"Q20852568"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"VI",
-    "wof:geomhash":"5052c38823424f82f71c6adc3340196d",
+    "wof:geomhash":"fc13adee267f974232c8737ea332608b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -247,7 +248,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921371,
+    "wof:lastmodified":1695885335,
     "wof:name":"Saint Croix",
     "wof:parent_id":85632169,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.